### PR TITLE
fix(deps): ignores requires-python in renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,13 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "description": [
     "Managed by khepri-deps/renovate — global config provides weekly Monday schedule, 14-day release cooldown, and vulnerability alert bypass."
+  ],
+  "packageRules": [
+    {
+      "description": "Do not modify requires-python — this is a minimum version constraint, not a pinnable dependency",
+      "matchDepNames": ["python"],
+      "matchManagers": ["pep621"],
+      "enabled": false
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- Disables Renovate management of requires-python via packageRules — it is a minimum version constraint, not a pinnable dependency
- Fixes PR #9 where Renovate pinned it to ==3.14.3, breaking CI